### PR TITLE
Remove duplication by using `to output` assertion

### DIFF
--- a/src/tests/painter.spec.js
+++ b/src/tests/painter.spec.js
@@ -45,62 +45,62 @@ describe('Painter', () => {
 
     it('outputs a single empty element', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div'
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
         '<div />');
     });
 
     it('outputs a single empty element with string attributes', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value: 'abc' },
                 { name: 'className', value: 'foo' }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div id="abc" className="foo" />');
     });
     
     it('skips outputting attributes that are undefined', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value: undefined },
                 { name: 'className', value: 'foo' }
             ]
-        }, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div className="foo" />');
     });
+
     it('outputs a single empty element with object attributes', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value: 'abc' },
                 { name: 'style', value: { width: 100, height: 200 } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div id="abc" style={{ width: 100, height: 200 }} />');
     });
 
     it('outputs many attributes over separate lines', () => {
-
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
@@ -110,17 +110,16 @@ describe('Painter', () => {
                 { name: 'style', value: { width: 100, height: 200 } },
                 { name: 'role', value: 'button-with-a-long-name' }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div id="abc" className="foo bah gah blah cheese" another="big long attribute value"\n' +
             '   style={{ width: 100, height: 200 }} role="button-with-a-long-name"\n' +
             '/>');
     });
     
     it('outputs a long function attribute without a body', () => {
-        
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'MyComponent',
             attributes: [
@@ -129,9 +128,10 @@ describe('Painter', () => {
                     console.log('with many lines');
                 } }
             ]
-        }, expect.diff, expect.inspect);
 
-        expect(pen.toString(), 'to equal',
+        };
+        
+        expect(description, 'to output',
             '<MyComponent onClick={function handleClick(a, b) { /* ... */ }} />');
         
     });
@@ -139,74 +139,73 @@ describe('Painter', () => {
 
     it('outputs a short one line function attribute with a body', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'MyComponent',
             attributes: [
                 { name: 'onClick', value: shortFunc }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<MyComponent onClick={function shortFunc(a, b) { return a + b; }} />');
 
     });
 
     it('outputs a short multi line function attribute without a body', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'MyComponent',
             attributes: [
                 { name: 'onClick', value: shortMultiLine }
             ]
-        }, expect.diff, expect.inspect);
+        }
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<MyComponent onClick={function shortMultiLine(a, b) { /* ... */ }} />');
 
     });
 
     it('outputs a long single line function attribute without a body', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'MyComponent',
             attributes: [
                 { name: 'onClick', value: longSingleLine }
             ]
-        }, expect.diff, expect.inspect);
-
-        expect(pen.toString(), 'to equal',
+        };
+        expect(description, 'to output',
             '<MyComponent onClick={function longSingleLine(a, b) { /* ... */ }} />');
 
     });
 
     it('outputs an expect.it assertion as an assertion and not a function', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'MyComponent',
             attributes: [
                 { name: 'onClick', value: expect.it('to be a function') }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<MyComponent onClick={expect.it(\'to be a function\')} />');
     });
 
     it('outputs a difference long function attribute with a body', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'MyComponent',
             attributes: [
                 { name: 'onClick', value: longFunc, diff: { type: 'changed', expectedValue: longFunc2 } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<MyComponent\n' +
             '   onClick={function longFunc(a, b) { /* ... */ }} // should be onClick={function longFunc2(a, b) { /* ... */ }}\n' +
             '                                                   // function longFunc2(a, b) {\n' +
@@ -227,15 +226,15 @@ describe('Painter', () => {
             return 'spy';
         };
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'MyComponent',
             attributes: [
                 { name: 'onClick', value: testFunc }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<MyComponent onClick={function spy} />');
 
 
@@ -243,15 +242,15 @@ describe('Painter', () => {
 
     it('outputs a changed attribute', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value: 'abc', diff: { type: 'changed', expectedValue: '123' } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div id="abc" // should be id="123"\n' +
             '              // -abc\n' +
             '              // +123\n' +
@@ -260,30 +259,30 @@ describe('Painter', () => {
 
     it('outputs a different attribute type', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value: '123', diff: { type: 'changed', expectedValue: 123 } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div id="123" // should be id={123}\n' +
             '/>');
     });
 
     it('outputs a different attribute type and value', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value: '123', diff: { type: 'changed', expectedValue: 1234 } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div id="123" // should be id={1234}\n' +
             '/>');
     });
@@ -291,15 +290,15 @@ describe('Painter', () => {
 
     it('outputs a different boolean attribute', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'disabled', value: true, diff: { type: 'changed', expectedValue: false } }
             ]
-        }, expect.diff, expect.inspect);
+        }
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div disabled={true} // should be disabled={false}\n' +
             '/>');
     });
@@ -307,15 +306,15 @@ describe('Painter', () => {
 
     it('outputs a changed attribute with an object diff', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value: { abc: 123, def: 'ghi' }, diff: { type: 'changed', expectedValue: { abc: 123, def: 'ghij' } } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             "<div id={{ abc: 123, def: 'ghi' }} // should be id={{ abc: 123, def: 'ghij' }}\n" +
             '                                   // {\n' +
             '                                   //   abc: 123,\n' +
@@ -335,15 +334,15 @@ describe('Painter', () => {
         } catch (e) {
             error = e;
         }
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value: { abc: 123, def: 'ghi' }, diff: { type: 'changed', error: error, expectedValue: { abc: 123, def: 'ghij' } } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             "<div\n" +
             "   id={{ abc: 123, def: 'ghi' }} // expected { abc: 123, def: 'ghi' } to satisfy { abc: 245 }\n" +
             '                                 //\n' +
@@ -356,15 +355,15 @@ describe('Painter', () => {
 
     it('outputs a missing attribute', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', diff: { type: 'missing', expectedValue: '123' } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div // missing id="123"\n' +
             '/>');
 
@@ -372,22 +371,22 @@ describe('Painter', () => {
 
     it('outputs an extra attribte', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
                 { name: 'id', value:'abc', diff: { type: 'extra' } }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div id="abc" // id should be removed\n' +
             '/>');
     });
 
     it('outputs an inspected object attribute over multiple lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
@@ -404,9 +403,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        }
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div // missing id={{\n' +
             "     //   test: 'one two three four five',\n" +
             "     //   foo: 'bar lah cheese',\n" +
@@ -427,7 +426,7 @@ describe('Painter', () => {
             error = e;
         }
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
@@ -441,7 +440,8 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
+        Painter(pen, description, expect.diff, expect.inspect);
         expect(pen.toString(), 'to equal', '<div\n' +
         "   data={{ a: 'hello', b: 'foo', c: false }} // expected { a: 'hello', b: 'foo', c: false } to satisfy { b: 'bar', c: true }\n" +
         '                                             //\n' +
@@ -459,7 +459,7 @@ describe('Painter', () => {
 
     it('outputs many attributes over multiple lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
@@ -471,9 +471,9 @@ describe('Painter', () => {
                 type: 'CONTENT',
                 value: 'one'
             }]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div id="very-long-attribute-value" data-value1="very-long-attribute-value"\n' +
                 '   data-value2="very-long-attribute-value">\n' +
             '  one\n' +
@@ -482,7 +482,7 @@ describe('Painter', () => {
 
     it('forces the children onto multiple lines when attributes are on multiple lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
@@ -500,9 +500,9 @@ describe('Painter', () => {
                 }
             ],
             children: [ { type: 'CONTENT', value: 'some text' }]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div // missing id={{\n' +
             "     //   test: 'one two three four five',\n" +
             "     //   foo: 'bar lah cheese',\n" +
@@ -516,7 +516,7 @@ describe('Painter', () => {
 
     it('outputs a single child element', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -524,9 +524,9 @@ describe('Painter', () => {
                   name: 'span'
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div><span /></div>');
 
     });
@@ -534,16 +534,16 @@ describe('Painter', () => {
 
     it('outputs many children split onto separate lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: duplicate(
                 { type: 'ELEMENT',
-                    name: 'span'
+                  name: 'span'
                 }, 12)
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  <span />\n' +
             '  <span />\n' +
@@ -562,7 +562,7 @@ describe('Painter', () => {
 
     it('outputs children with changes on separate lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -574,9 +574,9 @@ describe('Painter', () => {
                     ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
         '<div>\n' +
         '  <span id="abc" // should be id="abcd"\n' +
         '                 // -abc\n' +
@@ -587,7 +587,7 @@ describe('Painter', () => {
 
     it('outputs children with single line changes on separate lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -599,9 +599,9 @@ describe('Painter', () => {
                     ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  <span // missing id="abcd"\n' +
             '  />\n' +
@@ -610,7 +610,7 @@ describe('Painter', () => {
 
     it('outputs text content', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -619,16 +619,16 @@ describe('Painter', () => {
                     value: 'abc'
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>abc</div>');
 
     });
 
     it('outputs numeric content', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -637,16 +637,16 @@ describe('Painter', () => {
                     value: 42
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>42</div>');
 
     });
 
     it('outputs children with text content on separate lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: duplicate({
@@ -655,9 +655,9 @@ describe('Painter', () => {
                 attributes: [{ name: 'className', value: 'foo' }],
                 children: [{ type: 'CONTENT', value: 'text content' }]
             }, 3)
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  <span className="foo">text content</span>\n' +
             '  <span className="foo">text content</span>\n' +
@@ -668,7 +668,7 @@ describe('Painter', () => {
 
     it('outputs deep nested children', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: duplicate({
@@ -679,9 +679,9 @@ describe('Painter', () => {
                     { type: 'ELEMENT', name: 'strong', children: [ { type: 'CONTENT', value: 'text content' }] }
                 ]
             }, 3)
-        }, expect.diff, expect.inspect);
+        }
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  <span className="foo"><strong>text content</strong></span>\n' +
             '  <span className="foo"><strong>text content</strong></span>\n' +
@@ -691,7 +691,7 @@ describe('Painter', () => {
 
     it('outputs a changed text content', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -704,9 +704,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  abc // -abc\n' +
             '      // +abcd\n' +
@@ -716,7 +716,7 @@ describe('Painter', () => {
     
     it('outputs a changed numerical content', () => {
         
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -729,9 +729,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
         
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
           '<div>\n' +
           '  42 // should be 84\n' +
           '</div>');
@@ -740,7 +740,7 @@ describe('Painter', () => {
     
     it('outputs a multiline changed text content', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -753,9 +753,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  abc // -abc\n' +
             '  def // -def\n' +
@@ -768,7 +768,7 @@ describe('Painter', () => {
 
     it('outputs a changed type content', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -781,9 +781,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  123 // mismatched type -string\n' +
             '      //                 +number\n' +
@@ -793,7 +793,7 @@ describe('Painter', () => {
 
     it('outputs a changed type and value content', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -806,9 +806,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  -1234 // and mismatched type -string\n' +
             '  +123  //                     +number\n' +
@@ -818,7 +818,7 @@ describe('Painter', () => {
 
     it('outputs a missing child', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -831,9 +831,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
         '<div>\n' +
         '  // missing <span className="foo" />\n' +
         '</div>');
@@ -841,7 +841,7 @@ describe('Painter', () => {
 
     it('outputs a missing child in the middle of list of children', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -864,9 +864,9 @@ describe('Painter', () => {
                     attributes: [ { name: 'className', value: 'foo' } ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  <span className="foo" />\n' +
             '  // missing <span className="foo" />\n' +
@@ -876,7 +876,7 @@ describe('Painter', () => {
 
     it('outputs an extra element', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -889,9 +889,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  <span className="foo" /> // should be removed\n' +
             '</div>');
@@ -899,7 +899,7 @@ describe('Painter', () => {
 
     it('outputs an extra element over multiple lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -918,9 +918,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  <span className="foo" data-className1="foo" data-className2="foo" // should be removed\n' +
             '     data-className3="foo" data-className4="foo"                    //\n' +
@@ -930,7 +930,7 @@ describe('Painter', () => {
 
     it('outputs an extra element in the middle of the children', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -953,9 +953,9 @@ describe('Painter', () => {
                     attributes: [ { name: 'className', value: 'foo' } ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  <span className="foo" />\n' +
             '  <span className="foo" /> // should be removed\n' +
@@ -965,7 +965,7 @@ describe('Painter', () => {
 
     it('outputs a removed text element', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -977,9 +977,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  some text // should be removed\n' +
             '</div>');
@@ -987,7 +987,7 @@ describe('Painter', () => {
 
     it('outputs a removed text element over multiple lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -999,9 +999,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  some text      // should be removed\n' +
             '  some more text //\n' +
@@ -1010,7 +1010,7 @@ describe('Painter', () => {
 
     it('outputs a missing text element', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -1022,9 +1022,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  // missing some text\n' +
             '</div>');
@@ -1032,7 +1032,7 @@ describe('Painter', () => {
 
     it('outputs a missing text element over multiple lines', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             children: [
@@ -1044,9 +1044,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div>\n' +
             '  // missing some text\n' +
             '  //         some more text\n' +
@@ -1056,7 +1056,7 @@ describe('Painter', () => {
 
     it('outputs an extra wrapper', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             diff: {
@@ -1069,9 +1069,9 @@ describe('Painter', () => {
                     children: [ { type: 'CONTENT', value: 'some text' } ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        }
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div> // wrapper should be removed\n' +
             '  <span>some text</span>\n' +
             '</div> // wrapper should be removed');
@@ -1079,7 +1079,7 @@ describe('Painter', () => {
 
     it('outputs two levels of extra wrappers', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             diff: {
@@ -1097,9 +1097,9 @@ describe('Painter', () => {
                     } ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div> // wrapper should be removed\n' +
             '  <span> // wrapper should be removed\n' +
             '    <span>some text</span>\n' +
@@ -1109,7 +1109,7 @@ describe('Painter', () => {
 
     it('outputs a wrapper on separate line when the wrapper is not a diff', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'WRAPPERELEMENT',
             name: 'div',
             attributes: [{ name: 'className', value: 'foo' }],
@@ -1120,9 +1120,9 @@ describe('Painter', () => {
                     children: [ { type: 'CONTENT', value: 'some text' } ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div className="foo">\n' +
             '  <span>some text</span>\n' +
             '</div>');
@@ -1130,7 +1130,7 @@ describe('Painter', () => {
 
     it('outputs a wrapper greyed out when the wrapper is not a diff', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'WRAPPERELEMENT',
             name: 'div',
             attributes: [{ name: 'className', value: 'foo' }],
@@ -1141,7 +1141,8 @@ describe('Painter', () => {
                     children: [ { type: 'CONTENT', value: 'some text' } ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
+        Painter(pen, description, expect.diff, expect.inspect);
 
         expect(pen, 'to equal',
             expect.output.clone('text').gray('<div className="foo">')
@@ -1161,23 +1162,23 @@ describe('Painter', () => {
 
     it('outputs a different named element without attributes or children', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             diff: {
                 type: 'differentElement',
                 expectedName: 'span'
             }
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div // should be <span\n' +
             '/>');
     });
 
     it('outputs a different named element without attributes', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             diff: {
@@ -1193,9 +1194,9 @@ describe('Painter', () => {
                     } ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div // should be <span\n' +
             '>\n' +
             '  <span>some text</span>\n' +
@@ -1205,7 +1206,7 @@ describe('Painter', () => {
 
     it('outputs a different named element with attributes', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
@@ -1225,9 +1226,9 @@ describe('Painter', () => {
                     } ]
                 }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div // should be <span\n' +
             '   className="foo" id="abc123">\n' +
             '  <span>some text</span>\n' +
@@ -1236,7 +1237,7 @@ describe('Painter', () => {
 
     it('outputs a different named element with children but without attributes', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [],
@@ -1247,9 +1248,9 @@ describe('Painter', () => {
             children: [
                 { type: 'CONTENT', value: 'some text' }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div // should be <span\n' +
             '>\n' +
             '  some text\n' +
@@ -1258,9 +1259,9 @@ describe('Painter', () => {
 
     it('outputs a different named element with attributes in the middle of children', () => {
 
-        Painter(pen, {
-        type: 'ELEMENT',
-        name: 'body',
+        const description = {
+            type: 'ELEMENT',
+            name: 'body',
             children: [
                 { type: 'ELEMENT', name: 'span', children: [ { type: 'CONTENT', value: 'some text' } ] },
                 {
@@ -1286,9 +1287,9 @@ describe('Painter', () => {
                 },
                 { type: 'ELEMENT', name: 'span', children: [ { type: 'CONTENT', value: 'some text' } ] }
             ]
-    }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<body>\n' +
             '  <span>some text</span>\n' +
             '  <div // should be <span\n' +
@@ -1300,7 +1301,7 @@ describe('Painter', () => {
     });
 
     it('outputs a single line contentElementMismatch diff', () => {
-        Painter(pen, {
+        const description = {
             type: 'CONTENT',
             value: 'some content',
             diff: {
@@ -1314,15 +1315,15 @@ describe('Painter', () => {
                     ]
                 }
             }
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
         'some content // should be <div className="foo">some text</div>');
 
     });
 
     it('outputs a multi-line contentElementMismatch diff', () => {
-        Painter(pen, {
+        const description = {
             type: 'CONTENT',
             value: 'some content',
             diff: {
@@ -1340,9 +1341,9 @@ describe('Painter', () => {
                     ]
                 }
             }
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             'some content // should be <div className="foo">\n' +
             '             //             <some-long-element-name><child-element>some text</child-element></some-long-element-name>\n' +
             '             //           </div>');
@@ -1351,33 +1352,33 @@ describe('Painter', () => {
 
     it('forces a linebreak before a contentElementMismatch', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
-                name: 'div',
+            name: 'div',
             attributes: [],
             children: [
-            {
-                type: 'CONTENT',
-                value: 'two',
-                diff: {
-                    type: 'contentElementMismatch',
-                    expected: {
-                        type: 'ELEMENT',
-                        name: 'child',
-                        attributes: [],
-                        children: [
-                            {
-                                type: 'CONTENT',
-                                value: 'aa'
-                            }
-                        ]
+                {
+                    type: 'CONTENT',
+                    value: 'two',
+                    diff: {
+                        type: 'contentElementMismatch',
+                        expected: {
+                            type: 'ELEMENT',
+                            name: 'child',
+                            attributes: [],
+                            children: [
+                                {
+                                    type: 'CONTENT',
+                                    value: 'aa'
+                                }
+                            ]
+                        }
                     }
                 }
-            }
-        ]
-        }, expect.diff, expect.inspect);
+            ]
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
         '<div>\n' +
         '  two // should be <child>aa</child>\n' +
         '</div>');
@@ -1385,7 +1386,7 @@ describe('Painter', () => {
 
     it('outputs a single line elementContentMismatch diff', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
@@ -1401,15 +1402,15 @@ describe('Painter', () => {
             children: [
                 { type: 'CONTENT', value: 'some text' }
             ]
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div className="foo">some text</div> // should be \'some content\'');
     });
 
     it('outputs a multi-line elementContentMismatch diff', () => {
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [
@@ -1432,9 +1433,9 @@ describe('Painter', () => {
                     value: 'some content'
                 }
             }
-        }, expect.diff, expect.inspect);
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<div className="foo">                                            // should be \'some content\'\n' +
             '  <some-long-element-name className="very long list of classes"> //\n' +
             '    <child-element>some content</child-element>                  //\n' +
@@ -1443,34 +1444,34 @@ describe('Painter', () => {
     });
 
     it('outputs an element/content mismatch diff, and forces a line break before', () => {
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'div',
             attributes: [ { name: 'id', value: 'foo' } ],
             children: [
-            {
-                type: 'ELEMENT',
-                name: 'span',
-                attributes: [ { name: 'id', value: 'childfoo' }
-                ],
-                children: [ { type: 'CONTENT', value: 'one' }
-                ]
-            },
-            {
-                type: 'ELEMENT',
-                name: 'span',
-                attributes: [],
-                children: [ { type: 'CONTENT', value: 'two' }
-                ],
-                diff: {
-                    type: 'elementContentMismatch',
-                    expected: { type: 'CONTENT', value: 'some text' }
+                {
+                    type: 'ELEMENT',
+                    name: 'span',
+                    attributes: [ { name: 'id', value: 'childfoo' }
+                                ],
+                    children: [ { type: 'CONTENT', value: 'one' }
+                              ]
+                },
+                {
+                    type: 'ELEMENT',
+                    name: 'span',
+                    attributes: [],
+                    children: [ { type: 'CONTENT', value: 'two' }
+                              ],
+                    diff: {
+                        type: 'elementContentMismatch',
+                        expected: { type: 'CONTENT', value: 'some text' }
+                    }
                 }
-            }
-        ]
-        }, expect.diff, expect.inspect);
+            ]
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
         '<div id="foo">\n' +
         '  <span id="childfoo">one</span>\n' +
         '  <span>two</span> // should be \'some text\'\n' +
@@ -1491,7 +1492,7 @@ describe('Painter', () => {
          *   And should be one, two, three.
          */
 
-        Painter(pen, {
+        const description = {
             type: 'ELEMENT',
             name: 'span',
             attributes: [],
@@ -1512,9 +1513,9 @@ describe('Painter', () => {
                     }
                 }
             ]
-        });
+        };
 
-        expect(pen.toString(), 'to equal',
+        expect(description, 'to output',
             '<span>\n' +
             '  <Test>one</Test>\n' +
             '  // missing (found at index 2) <Test>two</Test>\n' +
@@ -1527,7 +1528,7 @@ describe('Painter', () => {
 
         it('outputs an extra className', () => {
 
-            Painter(pen, {
+            const description = {
                 type: 'ELEMENT',
                 name: 'div',
                 attributes: [
@@ -1541,16 +1542,16 @@ describe('Painter', () => {
                     }
                 ],
                 children: []
-            }, expect.diff, expect.inspect);
+            };
 
-            expect(pen.toString(), 'to equal',
+            expect(description, 'to output',
                 '<div className="one two three" // extra class \'two\'\n' +
                 '/>');
         });
 
         it('outputs a missing className', () => {
 
-            Painter(pen, {
+            const description = {
                 type: 'ELEMENT',
                 name: 'div',
                 attributes: [
@@ -1564,16 +1565,16 @@ describe('Painter', () => {
                     }
                 ],
                 children: []
-            }, expect.diff, expect.inspect);
+            };
 
-            expect(pen.toString(), 'to equal',
+            expect(description, 'to output',
                 '<div className="one three" // missing class \'cheese\'\n' +
                 '/>');
         });
 
         it('outputs an extra and a missing className', () => {
 
-            Painter(pen, {
+            const description = {
                 type: 'ELEMENT',
                 name: 'div',
                 attributes: [
@@ -1588,9 +1589,9 @@ describe('Painter', () => {
                     }
                 ],
                 children: []
-            }, expect.diff, expect.inspect);
+            };
 
-            expect(pen.toString(), 'to equal',
+            expect(description, 'to output',
                 '<div className="one three" // missing class \'cheese\'\n' +
                 '                           // extra class \'three\'\n' +
                 '/>');
@@ -1598,7 +1599,7 @@ describe('Painter', () => {
 
         it('outputs multiple extra classes', () => {
 
-            Painter(pen, {
+            const description = {
                 type: 'ELEMENT',
                 name: 'div',
                 attributes: [
@@ -1612,16 +1613,16 @@ describe('Painter', () => {
                     }
                 ],
                 children: []
-            }, expect.diff, expect.inspect);
+            };
 
-            expect(pen.toString(), 'to equal',
+            expect(description, 'to output',
                 '<div className="one three two" // extra classes \'two three\'\n' +
                 '/>');
         });
 
         it('outputs multiple missing classes', () => {
 
-            Painter(pen, {
+            const description = {
                 type: 'ELEMENT',
                 name: 'div',
                 attributes: [
@@ -1635,9 +1636,9 @@ describe('Painter', () => {
                     }
                 ],
                 children: []
-            }, expect.diff, expect.inspect);
+            };
 
-            expect(pen.toString(), 'to equal',
+            expect(description, 'to output',
                 '<div className="one three" // missing classes \'cheese another\'\n' +
                 '/>');
         });


### PR DESCRIPTION
In preparation to adding DOM output mode, I started refactoring the spec and removed some noise.

Note that there's one case left that still manually calls the Painter where I'm not quite sure why using the assertion makes the test fail.