### PR TITLE
Add .npmrc with package-lock = false

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false


### PR DESCRIPTION
Prevents `package-lock.json` from appearing after `npm install` (minor annoyance).